### PR TITLE
Remove italics from HotInvest title

### DIFF
--- a/src/presentation/components/common/benefits/benefits.tsx
+++ b/src/presentation/components/common/benefits/benefits.tsx
@@ -46,7 +46,7 @@ const Benefits = () => {
     return (
         <section id="beneficios" className={styles.section}>
             <h2 className={styles.title}>
-                Tudo o que você precisa, com a conta da <span style={{ color: "#EF5635" }}>Hot</span><span style={{ color: "#16487E", fontStyle: "italic" }}>Invest</span>.
+                Tudo o que você precisa, com a conta da <span style={{ color: "#EF5635" }}>Hot</span><span style={{ color: "#16487E" }}>Invest</span>.
             </h2>
             <div className={styles.grid}>
                 {BENEFITS.map((b, i) => (


### PR DESCRIPTION
## Summary
- update benefits section title to drop italic styling

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eadee4190832392b428b5111a21d0