### PR TITLE
Add hover & open animations

### DIFF
--- a/src/presentation/components/common/benefits/benefits.module.scss
+++ b/src/presentation/components/common/benefits/benefits.module.scss
@@ -60,6 +60,7 @@
   flex-direction: column;
   align-items: flex-start;
   min-height: 220px;
+  transition: box-shadow 0.3s, transform 0.3s;
   @media (max-width: 900px) {
     padding: 28px 16px 24px 16px;
     min-height: 180px;
@@ -73,6 +74,11 @@
     margin: 0 auto;
     box-sizing: border-box;
   }
+}
+
+.card:hover {
+  transform: scale(1.05);
+  box-shadow: 0 6px 20px rgba($color-primary, 0.4);
 }
 
 .icon {

--- a/src/presentation/components/common/benefits/benefits.tsx
+++ b/src/presentation/components/common/benefits/benefits.tsx
@@ -46,7 +46,7 @@ const Benefits = () => {
     return (
         <section id="beneficios" className={styles.section}>
             <h2 className={styles.title}>
-                Tudo o que você precisa, com a conta da <span style={{ color: "#EF5635" }}>Hot</span><span style={{ color: "#16487E", fontStyle: "italic" }}>Invest</span>.
+                Tudo o que você precisa, com a conta da <span style={{ color: "#EF5635" }}>Hot</span><span style={{ color: "#16487E" }}>Invest</span>.
             </h2>
             <div className={styles.grid}>
                 {BENEFITS.map((b, i) => (

--- a/src/presentation/components/common/faq/faq.module.scss
+++ b/src/presentation/components/common/faq/faq.module.scss
@@ -84,7 +84,7 @@
 }
 
 .card.open {
-  box-shadow: 0 4px 24px rgba(130,10,209,0.10);
+  box-shadow: 0 4px 24px rgba($color-primary, 0.4);
 }
 
 .answer {

--- a/src/presentation/components/common/mission/mission.module.scss
+++ b/src/presentation/components/common/mission/mission.module.scss
@@ -79,6 +79,12 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  transition: box-shadow 0.3s, transform 0.3s;
+}
+
+.card:hover {
+  transform: scale(1.05);
+  box-shadow: 0 6px 20px rgba($color-primary, 0.4);
 }
 
 .cardImage {

--- a/src/presentation/components/common/service/service.module.scss
+++ b/src/presentation/components/common/service/service.module.scss
@@ -123,8 +123,8 @@
 }
 
 .card:hover {
-  box-shadow: 0 4px 16px rgba(0,0,0,0.08);
-  transform: translateY(-2px);
+  transform: scale(1.05);
+  box-shadow: 0 6px 20px rgba($color-primary, 0.4);
 }
 
 .iconCol {


### PR DESCRIPTION
## Summary
- remove italic formatting from HotInvest title
- add card hover animation in Benefits section
- highlight open card in FAQ section with orange shadow
- add orange hover shadow to Service and Mission cards

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eadee4190832392b428b5111a21d0