### PR TITLE
Add mission auto carousel

### DIFF
--- a/src/presentation/components/common/benefits/benefits.module.scss
+++ b/src/presentation/components/common/benefits/benefits.module.scss
@@ -60,6 +60,7 @@
   flex-direction: column;
   align-items: flex-start;
   min-height: 220px;
+  transition: box-shadow 0.3s, transform 0.3s;
   @media (max-width: 900px) {
     padding: 28px 16px 24px 16px;
     min-height: 180px;
@@ -73,6 +74,11 @@
     margin: 0 auto;
     box-sizing: border-box;
   }
+}
+
+.card:hover {
+  transform: scale(1.05);
+  box-shadow: 0 6px 20px rgba($color-primary, 0.4);
 }
 
 .icon {

--- a/src/presentation/components/common/benefits/benefits.tsx
+++ b/src/presentation/components/common/benefits/benefits.tsx
@@ -46,7 +46,7 @@ const Benefits = () => {
     return (
         <section id="beneficios" className={styles.section}>
             <h2 className={styles.title}>
-                Tudo o que você precisa, com a conta da <span style={{ color: "#EF5635" }}>Hot</span><span style={{ color: "#16487E", fontStyle: "italic" }}>Invest</span>.
+                Tudo o que você precisa, com a conta da <span style={{ color: "#EF5635" }}>Hot</span><span style={{ color: "#16487E" }}>Invest</span>.
             </h2>
             <div className={styles.grid}>
                 {BENEFITS.map((b, i) => (

--- a/src/presentation/components/common/faq/faq.module.scss
+++ b/src/presentation/components/common/faq/faq.module.scss
@@ -84,7 +84,7 @@
 }
 
 .card.open {
-  box-shadow: 0 4px 24px rgba(130,10,209,0.10);
+  box-shadow: 0 4px 24px rgba($color-primary, 0.4);
 }
 
 .answer {

--- a/src/presentation/components/common/mission/mission.module.scss
+++ b/src/presentation/components/common/mission/mission.module.scss
@@ -3,7 +3,7 @@
 
 .section {
   width: 100%;
-  padding: 48px 2rem 0 2rem;
+  padding: 80px 2rem 40px 2rem;
   margin-top: 4rem;
   overflow-x: hidden;
   display: flex;
@@ -23,12 +23,6 @@
     align-items: flex-start;
     margin-right: 48px;
     margin-bottom: 24px;
-    .controls {
-        display: flex;
-        align-items: center;
-        gap: 16px;
-        font-size: 26px;
-    }
 }
 
 .title {
@@ -79,6 +73,12 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  transition: box-shadow 0.3s, transform 0.3s;
+}
+
+.card:hover {
+  transform: scale(1.05);
+  box-shadow: 0 6px 20px rgba($color-primary, 0.4);
 }
 
 .cardImage {
@@ -124,26 +124,6 @@
   transition: color 0.2s;
 }
 
-.prevBtn, .nextBtn {
-  background: $color-primaryHover;
-  border: none;
-  border-radius: 50%;
-  width: 42px;
-  height: 42px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #fff;
-  box-shadow: none;
-  margin-top: 1.4rem;
-  cursor: pointer;
-  transition: background 0.2s, border 0.2s;
-  margin: 0;
-}
-.prevBtn:hover, .nextBtn:hover {
-  background: $color-primary;
-  border: none;
-}
 
 @media (max-width: 1823px) {  
     .contentWrapper {
@@ -173,12 +153,6 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
- 
-        .controls {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
     }
 }
 
@@ -202,12 +176,6 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
- 
-        .controls {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
     }
   .carousel {
     width: 95vw;
@@ -237,29 +205,16 @@
   }
   .section {
     align-items: flex-start;
-    padding: 32px 0 0 0;
+    padding: 48px 0 24px 0;
   }
   .slide {
     flex: 0 0 100%;
     padding: 0 8px;
   }
-  .prevBtn, .nextBtn {
-    top: 0;
-    left: 0;
-  }
-  .nextBtn {
-    left: 56px;
-  } 
   .headerColumn {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-
-    .controls {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-}
+  }
 }

--- a/src/presentation/components/common/mission/mission.tsx
+++ b/src/presentation/components/common/mission/mission.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import useEmblaCarousel from 'embla-carousel-react';
-
-import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 
 import styles from './mission.module.scss';
 
@@ -66,45 +64,20 @@ export default function Mission() {
             '(min-width: 1024px)': { slidesToScroll: 3 },
         },
     });
-    const [canScrollPrev, setCanScrollPrev] = useState(false);
-    const [canScrollNext, setCanScrollNext] = useState(false);
-
-    const onSelect = useCallback(() => {
-        if (!emblaApi) return;
-        setCanScrollPrev(emblaApi.canScrollPrev());
-        setCanScrollNext(emblaApi.canScrollNext());
-    }, [emblaApi]);
-
     useEffect(() => {
         if (!emblaApi) return;
-        onSelect();
-        emblaApi.on('select', onSelect);
-        emblaApi.on('reInit', onSelect);
-    }, [emblaApi, onSelect]);
+        const timer = setInterval(() => {
+            if (!emblaApi) return;
+            emblaApi.scrollNext();
+        }, 5000);
+        return () => clearInterval(timer);
+    }, [emblaApi]);
 
     return (
         <section className={styles.section}>
             <div className={styles.contentWrapper}>
                 <div className={styles.headerColumn}>
                     <h2 className={styles.title}>Missão, visão e valores HotInvest</h2>
-                    <div className={styles.controls}>
-                        <button
-                            className={styles.prevBtn}
-                            aria-label="Anterior"
-                            onClick={() => emblaApi && emblaApi.scrollPrev()}
-                            disabled={!canScrollPrev}
-                        >
-                            <IconChevronLeft size={26} />
-                        </button>
-                        <button
-                            className={styles.nextBtn}
-                            aria-label="Próximo"
-                            onClick={() => emblaApi && emblaApi.scrollNext()}
-                            disabled={!canScrollNext}
-                        >
-                            <IconChevronRight size={26} />
-                        </button>
-                    </div>
                 </div>
                 <div className={styles.carouselWrapper}>
                     <div className={styles.carousel} ref={emblaRef}>

--- a/src/presentation/components/common/service/service.module.scss
+++ b/src/presentation/components/common/service/service.module.scss
@@ -123,8 +123,8 @@
 }
 
 .card:hover {
-  box-shadow: 0 4px 16px rgba(0,0,0,0.08);
-  transform: translateY(-2px);
+  transform: scale(1.05);
+  box-shadow: 0 6px 20px rgba($color-primary, 0.4);
 }
 
 .iconCol {


### PR DESCRIPTION
## Summary
- enlarge Mission section vertically
- remove manual navigation arrows and enable slow auto-looping

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eadee4190832392b428b5111a21d0