### PR TITLE
Add card image animation

### DIFF
--- a/src/presentation/components/ui/card/card.module.scss
+++ b/src/presentation/components/ui/card/card.module.scss
@@ -138,18 +138,31 @@
   }
 }
 
-.cardImg1 {
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 450px;
-  max-width: 100%;
-  height: auto;
-  @media (max-width: 1024px) {
-    width: 320px;
+  .cardImg1 {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 450px;
+    max-width: 100%;
+    height: auto;
+    animation: card-float 6s ease-in-out infinite;
+    @media (max-width: 1024px) {
+      width: 320px;
+    }
+    @media (max-width: 600px) {
+      width: 100%;
+      max-width: 320px;
+    }
   }
-  @media (max-width: 600px) {
-    width: 100%;
-    max-width: 320px;
+
+  @keyframes card-float {
+    0% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(-10px);
+    }
+    100% {
+      transform: translateY(0);
+    }
   }
-}


### PR DESCRIPTION
## Summary
- animate the credit card image with a gentle floating effect

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec3418fd48323947c9f31843818ce