### PR TITLE
Use FALE-CONOSCO image for contact section

### DIFF
--- a/src/presentation/assets/images/index.ts
+++ b/src/presentation/assets/images/index.ts
@@ -11,6 +11,7 @@ import SIMPLICIDADE from './SIMPLICIDADE.jpg'
 import VISAO from './VISAO.jpg'
 import MISSAO from './MISSAO.jpg'
 import HEADER_IMAGE from './HEADER_IMAGE.jpg'
+import FALE_CONOSCO from './FALE-CONOSCO.png'
 
 const IMAGE = {
   HEADER_IMAGE,
@@ -26,6 +27,7 @@ const IMAGE = {
   SIMPLICIDADE,
   VISAO,
   MISSAO,
+  FALE_CONOSCO,
 }
 
 export default IMAGE

--- a/src/presentation/components/common/service/service.module.scss
+++ b/src/presentation/components/common/service/service.module.scss
@@ -3,7 +3,9 @@
 
 .container {
   width: 100%;
-  background: linear-gradient(90deg, rgba(239,86,53,0.05) 0%, rgba(22,72,126,0.05) 100%);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
   padding: 64px 0;
   display: flex;
   justify-content: center;

--- a/src/presentation/components/common/service/service.tsx
+++ b/src/presentation/components/common/service/service.tsx
@@ -4,10 +4,15 @@ import { FiPhoneCall } from "react-icons/fi";
 import { FaHandPeace } from "react-icons/fa";
 
 import styles from "./service.module.scss";
+import { IMAGE } from "src/presentation/assets";
 
 export default function Service() {
     return (
-        <section id="atendimento" className={styles.container}>
+        <section
+            id="atendimento"
+            className={styles.container}
+            style={{ backgroundImage: `url(${IMAGE.FALE_CONOSCO.src})` }}
+        >
             <div className={styles.serviceSection}>
                 <div className={styles.left}>
                     <h2 className={styles.title}>Fale conosco</h2>


### PR DESCRIPTION
## Summary
- add FALE_CONOSCO image to IMAGE assets
- show the new image as the background of the Fale Conosco component

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d4b0b60c8323a8fb63cfbf7e6066