### PR TITLE
Adjust HotInvest text styling

### DIFF
--- a/src/presentation/components/common/benefits/benefits.tsx
+++ b/src/presentation/components/common/benefits/benefits.tsx
@@ -46,7 +46,7 @@ const Benefits = () => {
     return (
         <section id="beneficios" className={styles.section}>
             <h2 className={styles.title}>
-                Tudo o que você precisa, com a conta da <span style={{ color: "#EF5635" }}>Hot</span><span style={{ color: "#16487E" }}>Invest</span>.
+                Tudo o que você precisa, com a conta da <span style={{ color: "#EF5635" }}>Hot</span><span style={{ color: "#16487E", fontWeight: 600 }}>Invest</span>.
             </h2>
             <div className={styles.grid}>
                 {BENEFITS.map((b, i) => (

--- a/src/presentation/components/common/header/header.module.scss
+++ b/src/presentation/components/common/header/header.module.scss
@@ -34,7 +34,7 @@
         font-size: $font-large;
         color: $color-snow;
         line-height: 48px;
-        margin-bottom: 2rem;  
+        margin-bottom: 2rem;
         font-weight: 500;
          @media (max-width: 1024px) {
           font-size: 34px;
@@ -42,6 +42,10 @@
           font-weight: 500;
           color: $color-snow;
         }
+      }
+      .highlight {
+        background: rgba(255, 255, 255, 0.7);
+        padding: 0 0.25rem;
       }
     }
     .form-section {

--- a/src/presentation/components/common/steps-open/steps-open.tsx
+++ b/src/presentation/components/common/steps-open/steps-open.tsx
@@ -70,7 +70,7 @@ const StepsOpen = () => {
     return (
         <section className={styles.container}>
             <div id="abra-sua-conta" className={styles.section}>
-                <h2 className={styles.title}>Abra sua conta no Hot<span style={{ color: "#16487E" }}>Invest</span> em poucos minutos</h2>
+                <h2 className={styles.title}>Abra sua conta no Hot<span style={{ color: "#16487E", fontWeight: 600 }}>Invest</span> em poucos minutos</h2>
                 <div className={styles.cardWrapper}>
                     <div className={styles.card} ref={containerRef}>
                         <div className={styles.lineContainer}>

--- a/src/presentation/pages/home/home.tsx
+++ b/src/presentation/pages/home/home.tsx
@@ -1,4 +1,5 @@
 import { Meta, Navbar, Header, Footer, StepsOpen, Card, FAQ, Service, Benefits, Mission } from 'src/presentation/components'
+import headerStyles from 'src/presentation/components/common/header/header.module.scss'
 import { IMAGE } from 'src/presentation/assets'
 
 const Home = () => {
@@ -19,7 +20,7 @@ const Home = () => {
           <>
             Não é só um banco<br />
             É o futuro, do seu jeito<br />
-            É <span style={{ color: "#EF5635" }}>Hot</span><span style={{ color: "#16487E"}}>Invest</span>
+            É <span className={headerStyles.highlight}><span style={{ color: "#EF5635" }}>Hot</span><span style={{ color: "#16487E", fontWeight: 400 }}>Invest</span></span>
           </>
         }
         image={IMAGES.src}


### PR DESCRIPTION
## Summary
- highlight "HotInvest" on the home header with a translucent background
- lighten the blue "Invest" word across the site

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686402c921908323bc64c1af860e4055